### PR TITLE
Add full path for osx compatibility

### DIFF
--- a/circuits/make-figures.py
+++ b/circuits/make-figures.py
@@ -10,7 +10,8 @@ import os
 
 command = ''
 for name in filenames:
-    command += "echo {}/{}.svg --export-pdf={}/{}.pdf;\n".format(os.getcwd(),name, os.getcwd(),name)
+    command += "echo {}/{}.svg --export-pdf={}/{}.pdf;\n".format(
+            os.getcwd(),name, os.getcwd(),name)
 command = "({}) |\nDISPLAY= inkscape --shell".format(command)
 
 

--- a/circuits/make-figures.py
+++ b/circuits/make-figures.py
@@ -11,7 +11,7 @@ import os
 command = ''
 for name in filenames:
     command += "echo {}/{}.svg --export-pdf={}/{}.pdf;\n".format(
-            os.getcwd(),name, os.getcwd(),name)
+            os.getcwd(), name, os.getcwd(), name)
 command = "({}) |\nDISPLAY= inkscape --shell".format(command)
 
 

--- a/circuits/make-figures.py
+++ b/circuits/make-figures.py
@@ -6,13 +6,13 @@ filenames = [
     'loadedMode'
 ]
 
+import os
 
 command = ''
 for name in filenames:
-    command += "echo {}.svg --export-pdf={}.pdf;\n".format(name, name)
+    command += "echo {}/{}.svg --export-pdf={}/{}.pdf;\n".format(os.getcwd(),name, os.getcwd(),name)
 command = "({}) |\nDISPLAY= inkscape --shell".format(command)
 
 
-import os
 os.system(command)
 


### PR DESCRIPTION
inkscape in osx has an outstanding bug that requires all filenames to include a full path; make-figures.py did not do this and is updated here accordingly.

Fixes (#10)